### PR TITLE
Update arch version to 5.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ plot_utils.plot_performance_profiles(
 ### Dependencies
 The code was tested under `Python>=3.7` and uses these packages:
 
-- arch == 5.0.1
+- arch == 5.3.0
 - scipy >= 1.7.0
 - numpy >= 0.9.0
 - absl-py >= 1.16.4

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ here = pathlib.Path(__file__).parent.resolve()
 long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 install_requires = [
-    'arch == 5.0.1',
+    'arch >= 5.3.0',
     'scipy >= 1.7.0',
     'absl-py >= 0.9.0',
     'numpy >= 1.16.4',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ here = pathlib.Path(__file__).parent.resolve()
 long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 install_requires = [
-    'arch >= 5.3.0',
+    'arch == 5.3.0',
     'scipy >= 1.7.0',
     'absl-py >= 0.9.0',
     'numpy >= 1.16.4',


### PR DESCRIPTION
Update arch dependency to make rliable work with MacBook Pro M1 chip.

See #13