### PR TITLE
Fix vertical alignement of y labels

### DIFF
--- a/rliable/plot_utils.py
+++ b/rliable/plot_utils.py
@@ -483,11 +483,13 @@ def plot_probability_of_improvement(
       right_ylabel,
       fontweight='bold',
       rotation='horizontal',
+      va='bottom',
       fontsize=labelsize)
   ax.set_ylabel(
       left_ylabel,
       fontweight='bold',
       rotation='horizontal',
+      va='bottom',
       fontsize=labelsize)
   twin_ax.set_yticklabels(all_algorithm_y, fontsize=ticklabelsize)
   ax.set_yticklabels(all_algorithm_x, fontsize=ticklabelsize)
@@ -496,7 +498,6 @@ def plot_probability_of_improvement(
   ax.spines['left'].set_visible(False)
   twin_ax.spines['left'].set_visible(False)
   ax.yaxis.set_label_coords(-ylabel_x_coordinate, 1.0)
-  twin_ax.yaxis.set_label_coords(1 + 0.7 * ylabel_x_coordinate,
-                                 1 + 0.6 * ylabel_x_coordinate)
+  twin_ax.yaxis.set_label_coords(1 + 0.7 * ylabel_x_coordinate, 1.0)
 
   return ax


### PR DESCRIPTION
There's a slight shift in the position of the y-axis labels. This is all the more apparent when the size of the figures is reduced.

This PR fixes this.

Before:
![before](https://github.com/google-research/rliable/assets/45557362/3e50395e-b3ae-4017-9bf1-a1d241e35cc3)

After:
![after](https://github.com/google-research/rliable/assets/45557362/dbf95581-9fd4-4009-a42a-afcbef6b5f61)

To reproduce:

```python
from rliable import library as rly
from rliable import metrics
from rliable import plot_utils
import numpy as np

# Set the seed
np.random.seed(0)

# Pairs of normalized score matrices for pairs of algorithms we want to compare
algo_pairs = {
    "Algo A,Algo B": (np.random.rand(100, 5), np.random.rand(100, 5)),
    "Algo C,Algo D": (np.random.rand(100, 5), np.random.rand(100, 5)),
}
average_probabilities, average_prob_cis = rly.get_interval_estimates(algo_pairs, metrics.probability_of_improvement, reps=10)
ax = plot_utils.plot_probability_of_improvement(average_probabilities, average_prob_cis, figsize=(3, 1))

# Save the figure with tight bounding box
ax.figure.savefig("after.png", bbox_inches="tight")
```