### PR TITLE
Bump arch in patch version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ here = pathlib.Path(__file__).parent.resolve()
 long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 install_requires = [
-    'arch == 5.3.0',
+    'arch == 5.3.1',
     'scipy >= 1.7.0',
     'absl-py >= 0.9.0',
     'numpy >= 1.16.4',


### PR DESCRIPTION
For some reason, pip and other installers like poetry don't find arch==5.3.0 on pypi (they do find all other versions), wherefore I can't install rliable

```
pip install arch==5.3.0
ERROR: Could not find a version that satisfies the requirement arch==5.3.0 (from versions: 1.0, 2.0, 3.0, 3.1, 3.2, 4.0, 4.1, 4.2, 4.3, 4.3.1, 4.4.1, 4.5.0, 4.6.0, 4.7.0, 4.8.0, 4.8.1, 4.9.0, 4.9.1, 4.10.0, 4.11, 4.12, 4.13, 4.14, 4.15, 4.16, 4.16.1, 4.17, 4.18, 4.19, 5.0, 5.0.1, 5.1.0, 5.2.0, 5.3.1, 5.4.0, 5.5.0, 5.6.0, 6.0.0, 6.0.1, 6.1.0, 6.2.0, 6.3.0)
ERROR: No matching distribution found for arch==5.3.0
```